### PR TITLE
Tracing support for S3 client

### DIFF
--- a/configure.go
+++ b/configure.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"net/http"
 	"os"
 	"os/user"
 	"path"
@@ -106,11 +105,4 @@ func doConfigure(c *cli.Context) {
 	}
 	msg := "\nConfiguration written to " + getMcConfigFilename()
 	info(msg)
-}
-
-// NewClient - get new client
-func getNewClient(config *mcConfig) (*s3.Client, error) {
-	var trace s3Trace
-	s3client := s3.NewClient(&config.S3.Auth, http.DefaultTransport, trace)
-	return s3client, nil
 }

--- a/configure.go
+++ b/configure.go
@@ -108,9 +108,9 @@ func doConfigure(c *cli.Context) {
 	info(msg)
 }
 
+// NewClient - get new client
 func getNewClient(config *mcConfig) (*s3.Client, error) {
-	return &s3.Client{
-		Auth:      &config.S3.Auth,
-		Transport: http.DefaultTransport,
-	}, nil
+	var trace s3Trace
+	s3client := s3.NewClient(&config.S3.Auth, http.DefaultTransport, trace)
+	return s3client, nil
 }

--- a/main.go
+++ b/main.go
@@ -34,17 +34,11 @@ func init() {
 
 func main() {
 	app := cli.NewApp()
-	app.Flags = []cli.Flag{
-		cli.StringFlag{
-			Name:  "quiet, q",
-			Usage: "disable progress bar and other chatty console output",
-		},
-	}
-
 	app.Name = "mc"
 	app.Usage = "Minio Client for S3 Compatible Object Storage"
 	app.Version = "0.1.0"
 	app.Commands = options
+	app.Flags = flags
 	app.Author = "Minio.io"
 	app.EnableBashCompletion = true
 	app.Run(os.Args)

--- a/pkg/s3/bucket.go
+++ b/pkg/s3/bucket.go
@@ -66,15 +66,12 @@ func (c *Client) ListBuckets() ([]*Bucket, error) {
 	req := newReq(c.endpoint() + "/")
 	c.Auth.signRequest(req)
 
-	if c.Trace != nil {
-		c.Trace.Request(req)
-	}
-
 	res, err := c.transport().RoundTrip(req)
 	if err != nil {
 		return nil, err
 	}
 	defer res.Body.Close()
+
 	if res.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("s3: Unexpected status code %d fetching bucket list", res.StatusCode)
 	}

--- a/pkg/s3/bucket.go
+++ b/pkg/s3/bucket.go
@@ -65,6 +65,11 @@ func (a bySize) Less(i, j int) bool { return a[i].Size < a[j].Size }
 func (c *Client) ListBuckets() ([]*Bucket, error) {
 	req := newReq(c.endpoint() + "/")
 	c.Auth.signRequest(req)
+
+	if c.Trace != nil {
+		c.Trace.Request(req)
+	}
+
 	res, err := c.transport().RoundTrip(req)
 	if err != nil {
 		return nil, err

--- a/pkg/s3/client.go
+++ b/pkg/s3/client.go
@@ -55,12 +55,6 @@ const (
 	MaxKeys = 1000
 )
 
-// Client is an Amazon S3 client.
-type Client struct {
-	*Auth
-	Transport http.RoundTripper // or nil for the default
-}
-
 // Bucket - carries s3 bucket reply header
 type Bucket struct {
 	Name         string
@@ -88,6 +82,21 @@ type listBucketResults struct {
 	Delimiter      string
 	Prefix         string
 	CommonPrefixes []*Prefix
+}
+
+// Client is an Amazon S3 client.
+type Client struct {
+	*Auth
+	Transport http.RoundTripper // or nil for the default
+	Trace     HttpTracer        // if not nil, Tracing will be enabled
+}
+
+func NewClient(auth *Auth, transport http.RoundTripper, trace HttpTracer) *Client {
+	return &Client{
+		Auth:      auth,
+		Transport: transport,
+		Trace:     trace,
+	}
 }
 
 func (c *Client) transport() http.RoundTripper {
@@ -156,12 +165,6 @@ func parseListAllMyBuckets(r io.Reader) ([]*Bucket, error) {
 		return nil, err
 	}
 	return res.Buckets.Bucket, nil
-}
-
-// NewClient - get new client
-func NewClient(auth *Auth) (client *Client) {
-	client = &Client{auth, http.DefaultTransport}
-	return
 }
 
 // IsValidBucket reports whether bucket is a valid bucket name, per Amazon's naming restrictions.

--- a/pkg/s3/client.go
+++ b/pkg/s3/client.go
@@ -88,14 +88,12 @@ type listBucketResults struct {
 type Client struct {
 	*Auth
 	Transport http.RoundTripper // or nil for the default
-	Trace     HttpTracer        // if not nil, Tracing will be enabled
 }
 
-func NewClient(auth *Auth, transport http.RoundTripper, trace HttpTracer) *Client {
+func GetNewClient(auth *Auth, transport http.RoundTripper) *Client {
 	return &Client{
 		Auth:      auth,
 		Transport: transport,
-		Trace:     trace,
 	}
 }
 

--- a/pkg/s3/client.go
+++ b/pkg/s3/client.go
@@ -84,12 +84,13 @@ type listBucketResults struct {
 	CommonPrefixes []*Prefix
 }
 
-// Client is an Amazon S3 client.
+// Client holds Amazon S3 client credentials and flags.
 type Client struct {
-	*Auth
-	Transport http.RoundTripper // or nil for the default
+	*Auth                       // AWS auth credentials
+	Transport http.RoundTripper // or nil for the default behavior
 }
 
+// GetNewClient returns an initialized S3.Client structure.
 func GetNewClient(auth *Auth, transport http.RoundTripper) *Client {
 	return &Client{
 		Auth:      auth,

--- a/pkg/s3/httptrace.go
+++ b/pkg/s3/httptrace.go
@@ -21,16 +21,19 @@ import (
 	"net/http"
 )
 
-type HttpTracer interface {
+// HTTPTracer provides callback hook mechanism for HTTP transport.
+type HTTPTracer interface {
 	Request(req *http.Request)
 	Response(res *http.Response)
 }
 
+// RoundTripTrace interposes HTTP transport requests and respsonses using HTTPTracer hooks
 type RoundTripTrace struct {
-	Trace     HttpTracer
-	Transport http.RoundTripper
+	Trace     HTTPTracer        // User provides callback methods
+	Transport http.RoundTripper // HTTP transport that needs to be intercepted
 }
 
+// RoundTrip executes user provided request and response hooks for each HTTP call.
 func (t RoundTripTrace) RoundTrip(req *http.Request) (res *http.Response, err error) {
 	if t.Trace != nil {
 		t.Trace.Request(req)

--- a/pkg/s3/httptrace.go
+++ b/pkg/s3/httptrace.go
@@ -1,0 +1,26 @@
+/*
+ * Mini Object Storage, (C) 2015 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package s3
+
+import (
+	"net/http"
+)
+
+type HttpTracer interface {
+	Request(req *http.Request)
+	Response(res *http.Response)
+}

--- a/pkg/s3/xmltime.go
+++ b/pkg/s3/xmltime.go
@@ -67,6 +67,6 @@ func (c *xmlTime) UnmarshalXMLAttr(attr xml.Attr) error {
 	return nil
 }
 
-func (c *xmlTime) format() string {
+func (c *xmlTime) String() string {
 	return c.Time.Format(iso8601Format)
 }

--- a/s3-fs-cp.go
+++ b/s3-fs-cp.go
@@ -46,11 +46,7 @@ func startBar(size int64) *pb.ProgressBar {
 }
 
 func doFsCopy(c *cli.Context) {
-	mcConfig, err := getMcConfig()
-	if err != nil {
-		fatal(err.Error())
-	}
-	s3c, err := getNewClient(mcConfig)
+	s3c, err := getNewClient(c)
 	if err != nil {
 		fatal(err.Error())
 	}

--- a/s3-fs-ls.go
+++ b/s3-fs-ls.go
@@ -50,12 +50,7 @@ func printObject(date time.Time, v int64, key string) {
 func doFsList(c *cli.Context) {
 	var items []*s3.Item
 
-	config, err := getMcConfig()
-	if err != nil {
-		fatal(err.Error())
-	}
-
-	s3c, err := getNewClient(config)
+	s3c, err := getNewClient(c)
 	if err != nil {
 		fatal(err.Error())
 	}

--- a/s3-fs-mb.go
+++ b/s3-fs-mb.go
@@ -31,12 +31,8 @@ func doFsMb(c *cli.Context) {
 		fatal("Needs an argument <BucketName>")
 	}
 	bucketName := c.Args().Get(0)
-	var err error
-	auth, err := getMcConfig()
-	if err != nil {
-		fatal(err.Error())
-	}
-	s3c, err := getNewClient(auth)
+
+	s3c, err := getNewClient(c)
 	err = s3c.PutBucket(bucketName)
 	if err != nil {
 		fatal(err.Error())

--- a/s3-fs-options.go
+++ b/s3-fs-options.go
@@ -96,3 +96,11 @@ var options = []cli.Command{
 	sync,
 	configure,
 }
+
+var flags = []cli.Flag{
+	cli.StringFlag{
+		Name:  "verbose, V",
+		Value: "trace, quiet",
+		Usage: "[trace] enables HTTP tracing. [quiet] disables progress bar.",
+	},
+}

--- a/s3-fs-sync.go
+++ b/s3-fs-sync.go
@@ -69,11 +69,8 @@ func (w *walk) putWalk(p string, i os.FileInfo, err error) error {
 func doFsSync(c *cli.Context) {
 	var s3c *s3.Client
 	var err error
-	config, err := getMcConfig()
-	if err != nil {
-		fatal(err.Error())
-	}
-	s3c, err = getNewClient(config)
+
+	s3c, err = getNewClient(c)
 	if err != nil {
 		fatal(err.Error())
 	}

--- a/s3-trace.go
+++ b/s3-trace.go
@@ -1,0 +1,62 @@
+/*
+ * Mini Object Storage, (C) 2014,2015 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httputil"
+)
+
+type s3Trace struct {
+	BodyTraceFlag        bool      // Include Body
+	RequestTransportFlag bool      // Include additional http.Transport adds such as User-Agent
+	Writer               io.Writer // Console device to write to
+}
+
+// Trace HTTP Request
+func (t s3Trace) Request(req *http.Request) {
+	if t.RequestTransportFlag {
+		reqTrace, err := httputil.DumpRequestOut(req, t.BodyTraceFlag)
+		if err == nil {
+			t.trace(reqTrace)
+		}
+	} else {
+		reqTrace, err := httputil.DumpRequest(req, t.BodyTraceFlag)
+		if err == nil {
+			t.trace(reqTrace)
+		}
+	}
+}
+
+// Trace HTTP Response
+func (t s3Trace) Response(res *http.Response) {
+	resTrace, err := httputil.DumpResponse(res, t.BodyTraceFlag)
+	if err == nil {
+		t.trace(resTrace)
+	}
+}
+
+// Trace HTTP Response
+func (t s3Trace) trace(data []byte) {
+	if t.Writer != nil {
+		fmt.Fprintf(t.Writer, "%s\n", data)
+	} else {
+		fmt.Printf("%s\n", data)
+	}
+}

--- a/s3-trace.go
+++ b/s3-trace.go
@@ -31,32 +31,38 @@ type s3Trace struct {
 
 // Trace HTTP Request
 func (t s3Trace) Request(req *http.Request) {
+	origAuthKey := req.Header.Get("Authorization")
+	req.Header.Set("Authorization", "AWS **PASSWORD**STRIPPED**")
+
 	if t.RequestTransportFlag {
 		reqTrace, err := httputil.DumpRequestOut(req, t.BodyTraceFlag)
 		if err == nil {
-			t.trace(reqTrace)
+			t.print(reqTrace)
 		}
 	} else {
 		reqTrace, err := httputil.DumpRequest(req, t.BodyTraceFlag)
 		if err == nil {
-			t.trace(reqTrace)
+			t.print(reqTrace)
 		}
 	}
+
+	req.Header.Set("Authorization", origAuthKey)
 }
 
 // Trace HTTP Response
 func (t s3Trace) Response(res *http.Response) {
+
 	resTrace, err := httputil.DumpResponse(res, t.BodyTraceFlag)
 	if err == nil {
-		t.trace(resTrace)
+		t.print(resTrace)
 	}
 }
 
 // Trace HTTP Response
-func (t s3Trace) trace(data []byte) {
+func (t s3Trace) print(data []byte) {
 	if t.Writer != nil {
-		fmt.Fprintf(t.Writer, "%s\n", data)
+		fmt.Fprintf(t.Writer, "%s", data)
 	} else {
-		fmt.Printf("%s\n", data)
+		fmt.Printf("%s", data)
 	}
 }


### PR DESCRIPTION
Any command can be traced with --verbose=trace option.
```
# mc --verbose=trace ls s3://mybucket/
# mc --verbose=trace cp hello.txt s3://mybucket/
```